### PR TITLE
Add <disabled> checkbox to Widget PI

### DIFF
--- a/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.widget.txt
+++ b/Toolset/resources/supporting_files/property_definitions/com.livecode.interface.classic.widget.txt
@@ -6,6 +6,7 @@ name	Widget
 kind
 tooltip		
 visible		
+disabled	false	
 behavior
 layerMode
 customProperties		


### PR DESCRIPTION
This commit adds the <disabled> checkbox to the Widget PI. It appears under the <visible> checkbox. Enabling/disabling a control is a pretty common operation.
